### PR TITLE
Include Github workflow and script

### DIFF
--- a/.github/workflows/docker-hub.yml
+++ b/.github/workflows/docker-hub.yml
@@ -1,0 +1,30 @@
+name: Docker Hub
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ main ]
+    tags: [ '*' ]
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v1 
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+      
+      - name: Build and publish
+        run: |
+          # If it is a tag:
+          if [ -z "${GITHUB_REF##refs/tags/*}" ] ; then
+            ./scripts/docker-hub-publish.sh ${GITHUB_REF#refs/tags/}
+          else
+            ./scripts/docker-hub-publish.sh ${GITHUB_SHA}
+          fi

--- a/scripts/docker-hub-publish.sh
+++ b/scripts/docker-hub-publish.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+
+VERSION=$1
+
+if [[ -z "$1" ]] ; then
+    echo "Usage: ./scripts/docker-hub-publish.sh VERSION"
+    exit 1
+fi
+
+docker build . -t zeitgeistpm/zeitgeist-token-api:$1 -t zeitgeistpm/zeitgeist-token-api:latest
+docker push zeitgeistpm/zeitgeist-token-api:$1
+docker push zeitgeistpm/zeitgeist-token-api:latest


### PR DESCRIPTION
This PR includes a GitHub workflow to build and push the Zeitgeist-token-api docker images to Dockerhub. @sea212 Can you possibly help include the credentials to Dockerhub in this repository? Thanks. 